### PR TITLE
Owlot/feat prv as tcp service

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -1,4 +1,5 @@
 STATE_DIR=/mnt/crypt/db
+PRV_HOST=prv:5000
 
 # When running the dev stack, we need a way to have act communicate with our eth2 client.
 # If this client is running on the same machine, but in a different docker network,
@@ -19,5 +20,4 @@ BN_HOLESKY=http://eth2:5053
 BN_MAINNET=http://eth2:5052
 
 # Env vars needed for prv
-PRV_HOST=localhost:5000
-
+PRV_USER=db-prv

--- a/.env-example
+++ b/.env-example
@@ -8,6 +8,7 @@ VALIDATOR_DOCKER_NETWORK=rocketpool_net
 # Env vars needed for srv
 SRV_USER=db-srv
 SRV_LISTEN_PORT=8880
+FEE_SIGNER_ADDRESS=<public address matching the fee service's signing.key (0x0c39fC9A61AE74281ec06640bd2065E11751910A for vrün fee server signer)>
 
 # Env vars needed for act
 ACT_USER=db-act

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules
+.env
+vcs.json

--- a/compose.yaml
+++ b/compose.yaml
@@ -7,6 +7,7 @@ volumes:
 
 networks:
   proxy:
+  prv:
   validator:
     name: ${VALIDATOR_DOCKER_NETWORK:-${COMPOSE_PROJECT_NAME}_default}
     external: true
@@ -130,6 +131,7 @@ services:
       - 8081:${SRV_LISTEN_PORT:-8880}
     networks:
       - proxy
+      - prv
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.srv.rule=PathPrefix(`/`)"
@@ -151,6 +153,32 @@ services:
     depends_on:
       act-init-fifo:
         condition: service_completed_successfully
+
+  prv:
+    container_name: ${COMPOSE_PROJECT_NAME}-prv
+    user: ${PRV_USER:-db-prv}:${PRV_USER:-db-prv}
+    env_file:
+      - .env
+    build:
+      context: ${DOCKER_BUILD_PATH:-.}
+      dockerfile: prv.Dockerfile
+      args:
+        - PRV_USER=${PRV_USER:-db-prv}
+        - STATE_DIR=${STATE_DIR:-/mnt/crypt/db}
+      tags:
+        - vrun-db-prv:local-dev
+    profiles:
+      - db
+      - prv
+    networks:
+      - prv
+    volumes:
+      - type: volume
+        source: db-data
+        target: ${STATE_DIR:-/mnt/crypt/db}
+    configs:
+      - source: dot-env
+        target: /.env
 
   reverse-proxy:
     container_name: ${COMPOSE_PROJECT_NAME}-reverse-proxy
@@ -178,4 +206,4 @@ services:
     networks:
       - proxy
     profiles:
-      - db
+      - proxy

--- a/compose.yaml
+++ b/compose.yaml
@@ -7,7 +7,9 @@ volumes:
 
 networks:
   proxy:
+    name: ${PROXY_DOCKER_NETWORK:-vrun-proxy}
   prv:
+    name: vrun-db-prv
   validator:
     name: ${VALIDATOR_DOCKER_NETWORK:-${COMPOSE_PROJECT_NAME}_default}
     external: true
@@ -191,7 +193,7 @@ services:
       - --api.insecure=true
       - --serversTransport.insecureSkipVerify=true
       - --providers.docker
-      - --providers.docker.network=${COMPOSE_PROJECT_NAME}_proxy
+      - --providers.docker.network=vrun-proxy
       - --providers.docker.watch
       - --providers.docker.exposedByDefault=false
       - --entryPoints.web.address=:80

--- a/local-dev.md
+++ b/local-dev.md
@@ -40,6 +40,16 @@ docker compose --profile db up -d
 docker compose --profile db logs -f
 ```
 
+### Start the proxy service
+If you want to be able to connect to the APIs from a local running frontend, you can spin up the proxy service provided by Traefik
+```bash
+docker compose --profile proxy up -d
+```
+You can now query the db service on port 80 through the reverse proxy
+```bash
+curl http://localhost/admins
+```
+
 ### Rebuild image after code changes
 
 You can force a docker rebuild by running the following docker compose commands:
@@ -47,11 +57,45 @@ You can force a docker rebuild by running the following docker compose commands:
 **srv**
 ```bash
 docker compose build srv
+# optional, restart the srv container to use the newly built docker image
+docker compose --profile srv up -d
 ```
 
 **act**
 ```bash
 docker compose build act
+# optional, restart the act container to use the newly built docker image
+docker compose --profile act up -d
+```
+
+**prv**
+```bash
+docker compose build prv
+# optional, restart the prv container to use the newly built docker image
+docker compose --profile prv up -d
+```
+
+## Test the local environment
+
+The following tests can be used to make sure all services are connected properly.
+
+**Show running docker containers for vrun-db**
+```bash
+docker compose ps
+```
+Make sure the `vrun-db-srv` container is showing `(healthy)` in the STATUS
+
+**Jump into the srv docker and send a command to prv**
+```bash
+docker exec -it vrun-db-srv sh
+export ADDRESS="<your wallet address in lower case>"
+echo -e "CHAINID = 17000\nADDRESS = ${ADDRESS}\nCOMMAND = pubkey" | nc -w 1 prv 5000
+```
+
+**Jump into the srv docker and trigger a refresh for act**
+```bash
+docker exec -it vrun-db-srv sh
+echo 'rf' > $ACT_FIFO_DIR/$ACT_FIFO_FILE
 ```
 
 ## Additional notes

--- a/prv.Dockerfile
+++ b/prv.Dockerfile
@@ -1,0 +1,33 @@
+# Create binary package using node
+FROM node:23-alpine3.20 AS build
+
+WORKDIR /usr/app
+
+COPY . .
+
+RUN npm install && \
+    npx esbuild prv.js --bundle --outfile=build.cjs --format=cjs --platform=node && \
+    npx pkg --targets latest-alpine-x64  build.cjs
+
+# Create clean docker with just the needed binary and git
+FROM alpine:3.20
+
+ARG HOME_DIR=/usr/share/db
+ARG PRV_USER=db-prv
+ARG STATE_DIR=/mnt/crypt/db
+
+WORKDIR ${HOME_DIR}
+
+COPY --from=build /usr/app/build prv
+
+RUN apk add git && \
+    addgroup -S ${PRV_USER} && \
+    adduser -S ${PRV_USER} -G ${PRV_USER} -h ${HOME_DIR} && \
+    mkdir -p ${STATE_DIR} && \
+    chown -R ${PRV_USER}:${PRV_USER} ${HOME_DIR} ${STATE_DIR}
+
+VOLUME ${STATE_DIR}
+
+USER ${PRV_USER}
+
+ENTRYPOINT ["./prv"]

--- a/prv.js
+++ b/prv.js
@@ -5,7 +5,7 @@ import { randomSeed, privkeyFromPath, pubkeyFromPrivkey, generateKeystore, toHex
 import { bls12_381 } from '@noble/curves/bls12-381'
 import { ensureDirs, gitCheck, gitPush, workDir, chainIds, addressRegExp } from './lib.js'
 import { mkdirSync, existsSync, writeFileSync, readFileSync } from 'node:fs'
-import { createInterface } from 'node:readline'
+import { createServer } from 'node:net'
 
 ensureDirs()
 
@@ -28,75 +28,116 @@ ensureDirs()
 // keystore: return a JSON-encoded keystore for ADDRESS's key at KEYPATH (protected by KEYPASS)
 // sign:     return signature (hexstring) for MESSAGE using ADDRESS's key at KEYPATH
 
-const inputLines = []
-for await (const line of createInterface({input: process.stdin}))
-  inputLines.push(line)
+const [HOST, PORT] = process.env.PRV_HOST.split(':')
 
-const readLine = (variable) => {
-  const prefix = `${variable} = `
-  const line = inputLines.shift()
-  if (!(line && line.startsWith(prefix)))
-    throw new Error(`missing ${variable}`)
-  return line.slice(prefix.length)
-}
+createServer((stream) => {
+  console.log("Got new connection")
 
-const chainId = readLine('CHAINID')
-if (!(chainId in chainIds))
-  throw new Error('invalid chainId')
+  const inputLines = []
+  let buffer = ''
 
-const address = readLine('ADDRESS')
-if (!addressRegExp.test(address))
-  throw new Error('invalid address')
+  stream.on('data', function (data) {
+    buffer += data.toString();
+  })
 
-const chainPath = `${workDir}/${chainId}`
-const seedPath = `${chainPath}/${address}`
+  stream.on('end', function () {
+    buffer.split('\n').forEach(line => {
+      const trimmedLine = line.trim();
+      if (trimmedLine) inputLines.push(trimmedLine); // Ignore empty lines
+    });
+    handleRequest()
+    stream.end()
+  })
 
-const command = readLine('COMMAND')
+  stream.on('error', function (e) {
+    console.log(`Got error ${e}`)
+    stream.write(e)
+    console.log("Closing connection")
+    stream.end()
+  })
 
-if (command == 'generate') {
-  if (existsSync(seedPath))
-    console.log('exists')
-  else {
-    mkdirSync(chainPath, {recursive: true})
-    writeFileSync(seedPath, randomSeed(), {flag: 'wx'})
-    gitCheck(['add', seedPath], workDir, '', 'failed to add seed')
-    gitCheck(['diff', '--staged', '--name-status'], workDir,
-      output => (
-        !output.trimEnd().includes('\n') &&
-        output.trimEnd().split(/\s+/).join() == `A,${chainId}/${address}`
-      ),
-      'unexpected diff adding seed'
-    )
-    gitPush(address, workDir)
-    console.log('created')
+  stream.on('close', function (had_error) {
+    if(had_error) {
+      console.log("Connection closed unexpectedly.")
+    }
+    stream.end()
+  })
+
+  function readLine(variable) {
+    if (inputLines.length < 1) {
+      throw new Error(`readLine called for ${variable}, but no more lines to read!`)
+    }
+    const prefix = `${variable} = `
+    const line = inputLines.shift()
+    if (!(line && line.startsWith(prefix))) {
+      throw new Error(`missing ${variable}`)
+    }
+    return line.slice(prefix.length)
   }
-}
-else {
-  const seed = readFileSync(seedPath)
-  const path = readLine('KEYPATH')
-  const sk = privkeyFromPath(seed, path)
-  switch (command) {
-    case 'pubkey': {
-      const pk = pubkeyFromPrivkey(sk)
-      console.log(`0x${toHex(pk)}`)
-      break
+
+  function handleRequest() {
+    const chainId = readLine('CHAINID')
+    if (!(chainId in chainIds)) {
+      console.log(`Could not find chainId ${chainId} in chainIds list:`)
+      console.log(chainIds)
+      throw new Error('invalid chainId')
     }
-    case 'keystore': {
-      const pubkey = pubkeyFromPrivkey(sk)
-      const password = readLine('KEYPASS')
-      console.log(JSON.stringify(generateKeystore({sk, path, pubkey, password})))
-      break
+
+    const address = readLine('ADDRESS')
+    if (!addressRegExp.test(address))
+      throw new Error('invalid address')
+
+    const chainPath = `${workDir}/${chainId}`
+    const seedPath = `${chainPath}/${address}`
+
+    const command = readLine('COMMAND')
+
+    if (command == 'generate') {
+      if (existsSync(seedPath))
+        console.log('exists')
+      else {
+        mkdirSync(chainPath, {recursive: true})
+        writeFileSync(seedPath, randomSeed(), {flag: 'wx'})
+        gitCheck(['add', seedPath], workDir, '', 'failed to add seed')
+        gitCheck(['diff', '--staged', '--name-status'], workDir,
+          output => (
+            !output.trimEnd().includes('\n') &&
+            output.trimEnd().split(/\s+/).join() == `A,${chainId}/${address}`
+          ),
+          'unexpected diff adding seed'
+        )
+        gitPush(address, workDir)
+        console.log('created')
+      }
     }
-    case 'sign': {
-      const messageHex = readLine('MESSAGE')
-      if (!messageHex.startsWith('0x')) throw new Error('invalid message')
-      const message = Buffer.from(messageHex.slice(2), 'hex')
-      const htfEthereum = {DST: 'BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_POP_'}
-      const sig = bls12_381.sign(message, sk, htfEthereum)
-      console.log(`0x${toHex(sig)}`)
-      break
+    else {
+      const seed = readFileSync(seedPath)
+      const path = readLine('KEYPATH')
+      const sk = privkeyFromPath(seed, path)
+      switch (command) {
+        case 'pubkey': {
+          const pk = pubkeyFromPrivkey(sk)
+          console.log(`0x${toHex(pk)}`)
+          break
+        }
+        case 'keystore': {
+          const pubkey = pubkeyFromPrivkey(sk)
+          const password = readLine('KEYPASS')
+          console.log(JSON.stringify(generateKeystore({sk, path, pubkey, password})))
+          break
+        }
+        case 'sign': {
+          const messageHex = readLine('MESSAGE')
+          if (!messageHex.startsWith('0x')) throw new Error('invalid message')
+          const message = Buffer.from(messageHex.slice(2), 'hex')
+          const htfEthereum = {DST: 'BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_POP_'}
+          const sig = bls12_381.sign(message, sk, htfEthereum)
+          console.log(`0x${toHex(sig)}`)
+          break
+        }
+        default:
+          throw new Error('invalid command')
+      }
     }
-    default:
-      throw new Error('invalid command')
   }
-}
+}).listen(PORT);

--- a/srv.js
+++ b/srv.js
@@ -147,10 +147,17 @@ const normaliseData = (data, args) => {
 
 const requiredDeclaration = 'I accept the terms of service specified at https://vrün.com/terms ' +
                             '(version: 20241008) (sha256sum: 9320acb47c90bf307a274187f45bdfa114a6d1c3ecd0a4d9d23dc80e5e2bffbf terms.md).'
+
 const adminAddresses = [
   '0xB0De8cB8Dcc8c5382c4b7F3E978b491140B2bC55', // gov.ramana.eth
-  '0x0c39fC9A61AE74281ec06640bd2065E11751910A', // vrün fee server signer
 ].map(x => x.toLowerCase())
+// Add vrün fee server signer address provided through environment if set
+if(process.env.FEE_SIGNER_ADDRESS) {
+  console.debug(`Adding fee signing address ${process.env.FEE_SIGNER_ADDRESS} to admin addresses list.`)
+  adminAddresses.push(process.env.FEE_SIGNER_ADDRESS.toLowerCase())
+} else {
+  console.warn("WARN: no FEE_SIGNER_ADDRESS provided, the fee service will not be added to the admin addresses list.")
+}
 
 const typesForPUT = new Map()
 const typesForPOST = new Map()


### PR DESCRIPTION
This PR is a followup on https://github.com/stakevrun/db/pull/29 to provide the `prv` service in the docker compose file as well.

The service has been refactored to run a a TCP server dropping the previous dependency on a systemd provided socket.

In addition, the `srv` service now adds the `FEE_SIGNER_ADDRESS` to the list of admin addresses.