### PR TITLE
fix: credit API fails when log dir does not exist yet

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -1,5 +1,6 @@
 STATE_DIR=/mnt/crypt/db
 PRV_HOST=prv:5000
+LOG_LEVEL=warn
 
 # When running the dev stack, we need a way to have act communicate with our eth2 client.
 # If this client is running on the same machine, but in a different docker network,


### PR DESCRIPTION
## New functions (3f9de38f620f833e35503c90772e23317df2fa27)
Adds a couple of functions to handle checks and validations.

### getAddressCreditPath

Checks if the credit path already exists on the file system.
Will create the path if it doesn't exist yet and the `createDirIfnotExists` flag is set to `true`.
Returns the credit path if it exists or is created.
Returns undefined otherwise.

### validateAddressAcceptance

Checks if the acceptance file exists for the given chain and address.
Validates if the acceptance text is the same as the currently required acceptance.
Returns the acceptance path and the acceptance object if it exists and is valid.
Returns the acceptance path and undefined otherwise.

### validateTimestamp
Validates if the provided timestamp isn't greater than now.
Will return a 400 'Timestamp in future error' if the provided timestamp seems to be in the future.
Both the provided timestamp and the current time will be represented as an integer before comparison making sure we don't have any rounding differences.
Fixes a bug where `(Date.now() / 1000)` was used without rounding, causing the current timestamp representation to be slightly in the past sometimes compared to the provided timestamp.

### validateTSNotTooEarly
Validates if the last log entry isn't later than the provided timestamp.
Throws an error if the result is not a success.

## New logging feature (f86e293640bc79ac206143eee9cae5276ca162eb)
Creates an override for the `console.debug`, `console.info`, `console.warn` and `console.error` functions; prefixing the log lines with a timestamp and the log severity.
Based on the LOG_LEVEL environment variable (default `warn`), the lines will be printed to stdout or not shown at all providing an easier way to debug the API when needed.
Additional debug lines have been added to the code.

## Acceptance fix (0cb1dd019fe9e926754f8b450638691560bbb4e1)
Moves the `MAX_STRING_LENGTH` check to only be triggered on posted lists or objects. This fixes a bug where the acceptance text would trigger the max string length check.