### PR TITLE
fix: Array.toReversed() function not defined

### DIFF
--- a/act.Dockerfile
+++ b/act.Dockerfile
@@ -5,30 +5,38 @@ WORKDIR /usr/app
 
 COPY . .
 
-RUN npm install && \
-    npx esbuild act.js --bundle --outfile=build.cjs --format=cjs --platform=node && \
-    npx pkg --targets latest-alpine-x64  build.cjs
+RUN npm install esbuild postject && \
+    npx esbuild act.js --bundle --format=cjs --platform=node --outfile=build.cjs && \
+    echo '{ "main": "build.cjs", "output": "build.blob", "disableExperimentalSEAWarning": true }' > sea-config.json && \
+    node --experimental-sea-config sea-config.json && \
+    cp $(command -v node) act && \
+    npx postject act NODE_SEA_BLOB build.blob --sentinel-fuse NODE_SEA_FUSE_fce680ab2cc467b6e072b8b5df1996b2
 
 # Create clean docker with just the needed binary and git
 FROM alpine:3.20
 
 ARG HOME_DIR=/usr/share/db
 ARG ACT_FIFO_DIR=/run/act
-ARG ACT_USER=db-act
+ARG USER=db-act
 
 WORKDIR ${HOME_DIR}
 
-COPY --from=build /usr/app/build act
+COPY --from=build /usr/app/act act
+# Copy just the two libs needed for node to run from our base image.
+# If we install the full packages, our docker image will double in size and we really only need these 2 files.
+COPY --from=build /usr/lib/libstdc++.so.6 /usr/lib/libstdc++.so.6
+COPY --from=build /usr/lib/libgcc_s.so.1 /usr/lib/libgcc_s.so.1
+
 COPY ./scripts/docker-entrypoint.sh.act /usr/local/bin/docker-entrypoint.sh
 
-RUN apk add git inotify-tools && \
-    addgroup -S ${ACT_USER} && \
-    adduser -S ${ACT_USER} -G ${ACT_USER} -h ${HOME_DIR} && \
+RUN apk add -U --no-cache git inotify-tools && \
+    addgroup -S ${USER} && \
+    adduser -S ${USER} -G ${USER} -h ${HOME_DIR} && \
     mkdir -p ${ACT_FIFO_DIR} && \
-    chown -R ${ACT_USER}:${ACT_USER} ${HOME_DIR} ${ACT_FIFO_DIR}
+    chown -R ${USER}:${USER} ${HOME_DIR} ${ACT_FIFO_DIR}
 
 VOLUME ${ACT_FIFO_DIR}
 
-USER ${ACT_USER}
+USER ${USER}
 
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]

--- a/compose.yaml
+++ b/compose.yaml
@@ -3,6 +3,7 @@ name: vrun-db
 
 volumes:
   db-data:
+  prv-data:
   act-fifo:
 
 networks:
@@ -55,7 +56,7 @@ services:
       context: ${DOCKER_BUILD_PATH:-.}
       dockerfile: act.Dockerfile
       args:
-        - ACT_USER=${ACT_USER:-db-act}
+        - USER=${ACT_USER:-db-act}
         - STATE_DIR=${STATE_DIR:-/mnt/crypt/db}
       tags:
         - vrun-db-act:local-dev
@@ -122,7 +123,7 @@ services:
       context: ${DOCKER_BUILD_PATH:-.}
       dockerfile: srv.Dockerfile
       args:
-        - SRV_USER=${SRV_USER:-db-srv}
+        - USER=${SRV_USER:-db-srv}
         - STATE_DIR=${STATE_DIR:-/mnt/crypt/db}
       tags:
         - vrun-db-srv:local-dev
@@ -165,7 +166,7 @@ services:
       context: ${DOCKER_BUILD_PATH:-.}
       dockerfile: prv.Dockerfile
       args:
-        - PRV_USER=${PRV_USER:-db-prv}
+        - USER=${PRV_USER:-db-prv}
         - STATE_DIR=${STATE_DIR:-/mnt/crypt/db}
       tags:
         - vrun-db-prv:local-dev
@@ -176,7 +177,7 @@ services:
       - prv
     volumes:
       - type: volume
-        source: db-data
+        source: prv-data
         target: ${STATE_DIR:-/mnt/crypt/db}
     configs:
       - source: dot-env

--- a/prv.Dockerfile
+++ b/prv.Dockerfile
@@ -5,29 +5,36 @@ WORKDIR /usr/app
 
 COPY . .
 
-RUN npm install && \
-    npx esbuild prv.js --bundle --outfile=build.cjs --format=cjs --platform=node && \
-    npx pkg --targets latest-alpine-x64  build.cjs
+RUN npm install esbuild postject && \
+    npx esbuild prv.js --bundle --format=cjs --platform=node --outfile=build.cjs && \
+    echo '{ "main": "build.cjs", "output": "build.blob", "disableExperimentalSEAWarning": true }' > sea-config.json && \
+    node --experimental-sea-config sea-config.json && \
+    cp $(command -v node) server && \
+    npx postject server NODE_SEA_BLOB build.blob --sentinel-fuse NODE_SEA_FUSE_fce680ab2cc467b6e072b8b5df1996b2
 
 # Create clean docker with just the needed binary and git
 FROM alpine:3.20
 
 ARG HOME_DIR=/usr/share/db
-ARG PRV_USER=db-prv
+ARG USER=db-prv
 ARG STATE_DIR=/mnt/crypt/db
 
 WORKDIR ${HOME_DIR}
 
-COPY --from=build /usr/app/build prv
+COPY --from=build /usr/app/server server
+# Copy just the two libs needed for node to run from our base image.
+# If we install the full packages, our docker image will double in size and we really only need these 2 files.
+COPY --from=build /usr/lib/libstdc++.so.6 /usr/lib/libstdc++.so.6
+COPY --from=build /usr/lib/libgcc_s.so.1 /usr/lib/libgcc_s.so.1
 
-RUN apk add git && \
-    addgroup -S ${PRV_USER} && \
-    adduser -S ${PRV_USER} -G ${PRV_USER} -h ${HOME_DIR} && \
+RUN apk add -U --no-cache git && \
+    addgroup -S ${USER} && \
+    adduser -S ${USER} -G ${USER} -h ${HOME_DIR} && \
     mkdir -p ${STATE_DIR} && \
-    chown -R ${PRV_USER}:${PRV_USER} ${HOME_DIR} ${STATE_DIR}
+    chown -R ${USER}:${USER} ${HOME_DIR} ${STATE_DIR}
 
 VOLUME ${STATE_DIR}
 
-USER ${PRV_USER}
+USER ${USER}
 
-ENTRYPOINT ["./prv"]
+ENTRYPOINT ["./server"]

--- a/srv.Dockerfile
+++ b/srv.Dockerfile
@@ -5,29 +5,36 @@ WORKDIR /usr/app
 
 COPY . .
 
-RUN npm install && \
-    npx esbuild srv.js --bundle --outfile=build.cjs --format=cjs --platform=node && \
-    npx pkg --targets latest-alpine-x64  build.cjs
+RUN npm install esbuild postject && \
+    npx esbuild srv.js --bundle --format=cjs --platform=node --outfile=build.cjs && \
+    echo '{ "main": "build.cjs", "output": "build.blob", "disableExperimentalSEAWarning": true }' > sea-config.json && \
+    node --experimental-sea-config sea-config.json && \
+    cp $(command -v node) server && \
+    npx postject server NODE_SEA_BLOB build.blob --sentinel-fuse NODE_SEA_FUSE_fce680ab2cc467b6e072b8b5df1996b2
 
 # Create clean docker with just the needed binary and git
 FROM alpine:3.20
 
 ARG HOME_DIR=/usr/share/db
-ARG SRV_USER=db-srv
+ARG USER=db-srv
 ARG STATE_DIR=/mnt/crypt/db
 
 WORKDIR ${HOME_DIR}
 
-COPY --from=build /usr/app/build srv
+COPY --from=build /usr/app/server server
+# Copy just the two libs needed for node to run from our base image.
+# If we install the full packages, our docker image will double in size and we really only need these 2 files.
+COPY --from=build /usr/lib/libstdc++.so.6 /usr/lib/libstdc++.so.6
+COPY --from=build /usr/lib/libgcc_s.so.1 /usr/lib/libgcc_s.so.1
 
-RUN apk add git && \
-    addgroup -S ${SRV_USER} && \
-    adduser -S ${SRV_USER} -G ${SRV_USER} -h ${HOME_DIR} && \
+RUN apk add -U --no-cache git && \
+    addgroup -S ${USER} && \
+    adduser -S ${USER} -G ${USER} -h ${HOME_DIR} && \
     mkdir -p ${STATE_DIR} && \
-    chown -R ${SRV_USER}:${SRV_USER} ${HOME_DIR} ${STATE_DIR}
+    chown -R ${USER}:${USER} ${HOME_DIR} ${STATE_DIR}
 
 VOLUME ${STATE_DIR}
 
-USER ${SRV_USER}
+USER ${USER}
 
-ENTRYPOINT ["./srv"]
+ENTRYPOINT ["./server"]


### PR DESCRIPTION
We were using the (already deprecated) `pkg` https://github.com/vercel/pkg module to package the code into a single binary. `pkg` helps creating nice small binaries, but in doing so, it appears not all functionality is being added.
This resulted in errors when trying to call `toReversed()` in our code.

This pr adds a change where `pkg` is replaced with `postject` in combination with `SEA` which has been added since node version 21 (https://nodejs.org/api/single-executable-applications.html). This results in slightly bigger docker images (275MB vs 119MB when using `pkg`) but at least we'll have access to all node api's now :wink: 

This PR also inclused a fix for `prv` which was pointing to the same volume as `srv` while it should have it's own private volume instead.