### PR TITLE
feat: use nc when services run within docker

### DIFF
--- a/act.Dockerfile
+++ b/act.Dockerfile
@@ -29,6 +29,9 @@ COPY --from=build /usr/lib/libgcc_s.so.1 /usr/lib/libgcc_s.so.1
 
 COPY ./scripts/docker-entrypoint.sh.act /usr/local/bin/docker-entrypoint.sh
 
+# Set env var so we can check in our code if we're running in docker or not
+ENV IS_DOCKER=1
+
 RUN apk add -U --no-cache git inotify-tools && \
     addgroup -S ${USER} && \
     adduser -S ${USER} -G ${USER} -h ${HOME_DIR} && \

--- a/prv.Dockerfile
+++ b/prv.Dockerfile
@@ -27,6 +27,9 @@ COPY --from=build /usr/app/server server
 COPY --from=build /usr/lib/libstdc++.so.6 /usr/lib/libstdc++.so.6
 COPY --from=build /usr/lib/libgcc_s.so.1 /usr/lib/libgcc_s.so.1
 
+# Set env var so we can check in our code if we're running in docker or not
+ENV IS_DOCKER=1
+
 RUN apk add -U --no-cache git && \
     addgroup -S ${USER} && \
     adduser -S ${USER} -G ${USER} -h ${HOME_DIR} && \

--- a/srv.Dockerfile
+++ b/srv.Dockerfile
@@ -27,6 +27,9 @@ COPY --from=build /usr/app/server server
 COPY --from=build /usr/lib/libstdc++.so.6 /usr/lib/libstdc++.so.6
 COPY --from=build /usr/lib/libgcc_s.so.1 /usr/lib/libgcc_s.so.1
 
+# Set env var so we can check in our code if we're running in docker or not
+ENV IS_DOCKER=1
+
 RUN apk add -U --no-cache git && \
     addgroup -S ${USER} && \
     adduser -S ${USER} -G ${USER} -h ${HOME_DIR} && \


### PR DESCRIPTION
Added an `IS_DOCKER` env var in our Dockerfile's to indicate that we're running inside a docker image.
This is used to determine if we have `node` available or not.
Since the dockers we're creating are using the vanilla alpine images, we won't have the `node` package installed but we do have access to `nc`.